### PR TITLE
[#71] feat: 게시판에서 게시물 클릭 시 일치하는 상세 페이지로 이동

### DIFF
--- a/src/common/components/atom/board/Board.tsx
+++ b/src/common/components/atom/board/Board.tsx
@@ -1,4 +1,4 @@
-import { BoardBox, BoardHeaderBox, BoardItemBox, BoardRowBox } from "./BoardStyles";
+import { BoardBox, BoardHeaderBox, BoardItemBox, BoardLink, BoardRowBox } from "./BoardStyles";
 
 interface Props {
   boardlist: {
@@ -35,7 +35,9 @@ const Board = ({ boardlist }: Props) => {
         return (
           <BoardRowBox key={id}>
             <BoardItemBox>{index + 1}</BoardItemBox>
-            <BoardItemBox>{title}</BoardItemBox>
+            <BoardItemBox>
+              <BoardLink to={`./board/${id}`}>{title}</BoardLink>
+            </BoardItemBox>
             <BoardItemBox>{owner}</BoardItemBox>
             <BoardItemBox>{formatDate(createdAt)}</BoardItemBox>
             <BoardItemBox>{views}</BoardItemBox>

--- a/src/common/components/atom/board/BoardStyles.ts
+++ b/src/common/components/atom/board/BoardStyles.ts
@@ -1,5 +1,6 @@
 import tw from "twin.macro";
 import styled from "styled-components";
+import { Link } from "react-router-dom";
 
 export const BoardBox = styled.div`
   ${tw`
@@ -65,6 +66,13 @@ export const BoardItemBox = styled.div`
       justify-start
     `}
   }
+`;
+
+export const BoardLink = styled(Link)`
+  ${tw`
+    flex
+    w-full
+  `}
 `;
 
 export const BoardRowBox = styled.div`

--- a/src/common/components/templates/BoardWrite.tsx
+++ b/src/common/components/templates/BoardWrite.tsx
@@ -19,7 +19,7 @@ import helmet from "~/assets/images/helmet.svg";
 import usePostWrite from "~/common/hooks/write/mutate/usePostWrite";
 
 interface Props {
-  section: string;
+  section?: string;
 }
 
 const BoardWrite = ({ section }: Props) => {

--- a/src/common/components/templates/BoardWrite.tsx
+++ b/src/common/components/templates/BoardWrite.tsx
@@ -19,7 +19,7 @@ import helmet from "~/assets/images/helmet.svg";
 import usePostWrite from "~/common/hooks/write/mutate/usePostWrite";
 
 interface Props {
-  section?: string;
+  section: string;
 }
 
 const BoardWrite = ({ section }: Props) => {

--- a/src/common/components/templates/boardDetail/BoardDetail.tsx
+++ b/src/common/components/templates/boardDetail/BoardDetail.tsx
@@ -36,7 +36,7 @@ interface Props {
 
 const BoardDetail = ({ singleBoardId }: Props) => {
   const { singleBoard, isLoading } = useGetSingleBoard(singleBoardId);
-  
+
   // TODO: [2024-10-27] 임시 댓글 목록 상수 데이터를 이용하여 구현. 댓글 조회 api 구현 이후 수정 및 삭제 필요.
   const commentData = COMMENT_TEMPORORY_DATA;
 

--- a/src/pages/board/BoardDetailPage.tsx
+++ b/src/pages/board/BoardDetailPage.tsx
@@ -1,8 +1,14 @@
+import { useParams } from "react-router-dom";
+import ErrorMessage from "~/common/components/atom/ErrorMessage";
 import BoardDetail from "~/common/components/templates/boardDetail/BoardDetail";
 
 const BoardDetailPage = () => {
   // TODO: [2024-10-26] 조회할 게시글의 아이디를 임의로 적용. 추후 수정 필요.
-  const singleBoardId = "26";
+  const singleBoardId = useParams().id;
+
+  if (!singleBoardId) {
+    return <ErrorMessage text="잘못된 접근입니다." />;
+  }
 
   return <BoardDetail singleBoardId={singleBoardId} />;
 };

--- a/src/pages/board/BoardDetailPage.tsx
+++ b/src/pages/board/BoardDetailPage.tsx
@@ -7,7 +7,8 @@ const BoardDetailPage = () => {
   const singleBoardId = useParams().id;
 
   if (!singleBoardId) {
-    return <ErrorMessage text="잘못된 접근입니다." />;
+    console.log("올바른 singleBoardId가 존재하지 않습니다.");
+    return <ErrorMessage text="올바른 접근이 아닙니다." />;
   }
 
   return <BoardDetail singleBoardId={singleBoardId} />;

--- a/src/pages/common/BoardWritePage.tsx
+++ b/src/pages/common/BoardWritePage.tsx
@@ -1,8 +1,14 @@
 import { useParams } from "react-router-dom";
+import ErrorMessage from "~/common/components/atom/ErrorMessage";
 import BoardWrite from "~/common/components/templates/BoardWrite";
 
 const BoardWritePage = () => {
   const { section } = useParams();
+
+  if (!section) {
+    console.log("올바른 section이 존재하지 않습니다.");
+    return <ErrorMessage text="올바른 접근이 아닙니다." />;
+  }
 
   return <BoardWrite section={section} />;
 };

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -24,7 +24,6 @@ import BoardDetailPage from "~/pages/board/BoardDetailPage";
 import BoardWritePage from "~/pages/common/BoardWritePage";
 import AdminPage from "~/pages/admin/AdminPage";
 
-
 const Router = () => {
   return (
     <BrowserRouter basename="/jeju-deers-frontend">
@@ -49,7 +48,7 @@ const Router = () => {
             <Route path="schedule" element={<SchedulePage />} />
             <Route path="news" element={<NewsPage />} />
             <Route path=":section/write" element={<BoardWritePage />} />
-            <Route path=":section/board_detail" element={<BoardDetailPage />} />
+            <Route path=":section/board/:id" element={<BoardDetailPage />} />
           </Route>
 
           <Route path="teamroom">
@@ -60,7 +59,7 @@ const Router = () => {
             <Route path="playbook" element={<PlaybookPage />} />
             <Route path="membership_fee" element={<MembershipFeePage />} />
             <Route path=":section/write" element={<BoardWritePage />} />
-            <Route path=":section/board_detail" element={<BoardDetailPage />} />
+            <Route path=":section/board/:id" element={<BoardDetailPage />} />
           </Route>
 
           <Route path="community">
@@ -68,7 +67,7 @@ const Router = () => {
             <Route path="media" element={<MediaPage />} />
             <Route path="support" element={<SupportPage />} />
             <Route path=":section/write" element={<BoardWritePage />} />
-            <Route path=":section/board_detail" element={<BoardDetailPage />} />
+            <Route path=":section/board/:id" element={<BoardDetailPage />} />
           </Route>
         </Route>
 


### PR DESCRIPTION
<!--
- PR 제목은 다음과 같이 작성해주세요!
- [#이슈번호] commit type: PR 제목
> ex) [#25] feat: HomePage 컴포넌트 구현 -->

## 📌 이슈 번호

- close #71 

## ✅ 작업 내용

- 게시판에서 게시물 클릭 시 일치하는 상세 페이지로 이동
  - 클릭 시, 해당 게시물 id를 담은 링크와 BoardDetail 컴포넌트의 라우터 링크를 일치시킴. `./board/${id}`
  - 리다이렉션(페이지 전환) 없이 상세 페이지로 이동
  - useParams를 이용해, URL에서 id 파라미터 값을 가져오도록 함

- useParams의 section, id 타입에 `undefined`를 허용하여 type 오류 해결
  - `undefined`일 경우, ErrorMessage 컴포넌트를 띄우도록 수정
  - 올바른 값을 받지 못하는 경우, 원하는 경로로 이동 불가능

## 📷 스크린샷 (선택)

## 🔍 참고 자료 (선택)

<!-- 작업한 내용에 대한 부연 설명 -->
- useParams로 올바른 값을 전달 받을 수 없는 경우, 하위 컴포넌트가 props를 전달 받을 필요가 없어 useParams를 선언한 컴포넌트에서 이 경우에 대한 처리를 해주었습니다.
  - 이때, 다른 오류 메시지를 띄워주거나 기본 값을 지정해주어, 기본 경로로 이동하도록 설정해도 좋을 것 같아 의견 나눠보고 싶어요:)
```
// 예시
if(!singleBoardId){
  return <ErrorMessage />
}
```

## 💭 기타 (선택)

<!--
- 추가로 필요한 작업 내용
- 리뷰 요구사항
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
