### PR TITLE
[#58] feat: 게시판 상세페이지 내 댓글 작성 기능 구현

### DIFF
--- a/src/common/components/templates/boardDetail/BoardDetail.tsx
+++ b/src/common/components/templates/boardDetail/BoardDetail.tsx
@@ -41,11 +41,9 @@ const BoardDetail = ({ singleBoardId }: Props) => {
   // TODO: [2024-10-27] 임시 댓글 목록 상수 데이터를 이용하여 구현. 댓글 조회 api 구현 이후 수정 및 삭제 필요.
   const commentData = COMMENT_TEMPORORY_DATA;
 
-  if (isLoading) {
-    return <PendingMessage />;
-  }
-
   const { title, content, owner, belong, type, createdAt, views } = singleBoard;
+
+  const loginOwner = localStorage.getItem("owner");
 
   const { year, month, day, hours, minutes } = useFormatKoreanTime(createdAt);
 
@@ -65,6 +63,10 @@ const BoardDetail = ({ singleBoardId }: Props) => {
   const handleScrollTop = () => {
     window.scrollTo({ top: 0 });
   };
+
+  if (isLoading) {
+    return <PendingMessage />;
+  }
 
   return (
     <BoardDetailLayout>
@@ -126,7 +128,7 @@ const BoardDetail = ({ singleBoardId }: Props) => {
         ))}
         <CommentFieldBox>
           <CommentInformationBox>
-            <Text text="박재광" className="text-xl" />
+            <Text text={loginOwner || "알 수 없음"} className="text-xl" />
             <CommentTextArea placeholder="댓글을 남겨보세요" />
           </CommentInformationBox>
           <CommentSubmitButtonBox>

--- a/src/common/components/templates/boardDetail/BoardDetail.tsx
+++ b/src/common/components/templates/boardDetail/BoardDetail.tsx
@@ -11,6 +11,7 @@ import {
   CommentInformationBox,
   CommentSeparateLineBox,
   CommentSubmitButtonBox,
+  CommentTextArea,
   ContentBox,
   CreationInformationBox,
   DetailToBoardBox,
@@ -126,7 +127,7 @@ const BoardDetail = ({ singleBoardId }: Props) => {
         <CommentFieldBox>
           <CommentInformationBox>
             <Text text="박재광" className="text-xl" />
-            <Text text="댓글을 남겨보세요" className="text-4.5 text-gray-500" />
+            <CommentTextArea placeholder="댓글을 남겨보세요" />
           </CommentInformationBox>
           <CommentSubmitButtonBox>
             <Button text="등록" styleType="submitCommentButton" />

--- a/src/common/components/templates/boardDetail/BoardDetail.tsx
+++ b/src/common/components/templates/boardDetail/BoardDetail.tsx
@@ -30,6 +30,7 @@ import { Link } from "react-router-dom";
 import TAB_MENU_ITEMS, { TabMenuItems } from "~/constants/tabMenuItems";
 import useFormatKoreanTime from "~/hooks/board/useFormatKoreanTime";
 import COMMENT_TEMPORORY_DATA from "~/constants/commentTemporaryData";
+import { useState } from "react";
 
 interface Props {
   singleBoardId: string;
@@ -37,6 +38,12 @@ interface Props {
 
 const BoardDetail = ({ singleBoardId }: Props) => {
   const { singleBoard, isLoading } = useGetSingleBoard(singleBoardId);
+
+  const [comment, setComment] = useState("");
+
+  if (isLoading) {
+    return <PendingMessage />;
+  }
 
   // TODO: [2024-10-27] 임시 댓글 목록 상수 데이터를 이용하여 구현. 댓글 조회 api 구현 이후 수정 및 삭제 필요.
   const commentData = COMMENT_TEMPORORY_DATA;
@@ -64,9 +71,9 @@ const BoardDetail = ({ singleBoardId }: Props) => {
     window.scrollTo({ top: 0 });
   };
 
-  if (isLoading) {
-    return <PendingMessage />;
-  }
+  const handleSubmitComment = () => {
+    console.log(comment);
+  };
 
   return (
     <BoardDetailLayout>
@@ -129,10 +136,14 @@ const BoardDetail = ({ singleBoardId }: Props) => {
         <CommentFieldBox>
           <CommentInformationBox>
             <Text text={loginOwner || "알 수 없음"} className="text-xl" />
-            <CommentTextArea placeholder="댓글을 남겨보세요" />
+            <CommentTextArea
+              placeholder="댓글을 남겨보세요"
+              value={comment}
+              onChange={(event) => setComment(event.target.value)}
+            />
           </CommentInformationBox>
           <CommentSubmitButtonBox>
-            <Button text="등록" styleType="submitCommentButton" />
+            <Button text="등록" styleType="submitCommentButton" onClick={handleSubmitComment} />
           </CommentSubmitButtonBox>
         </CommentFieldBox>
       </PostDetailBox>

--- a/src/common/components/templates/boardDetail/BoardDetail.tsx
+++ b/src/common/components/templates/boardDetail/BoardDetail.tsx
@@ -50,9 +50,9 @@ const BoardDetail = ({ singleBoardId }: Props) => {
 
   const { title, content, owner, belong, type, createdAt, views } = singleBoard;
 
-  const loginOwner = localStorage.getItem("owner");
-
   const { year, month, day, hours, minutes } = useFormatKoreanTime(createdAt);
+
+  const loginOwner = localStorage.getItem("owner");
 
   const findBoardRoute = (type: string) => {
     for (const category in TAB_MENU_ITEMS) {
@@ -72,6 +72,10 @@ const BoardDetail = ({ singleBoardId }: Props) => {
   };
 
   const handleSubmitComment = () => {
+    if (!comment) {
+      alert("댓글을 입력해주세요.");
+    }
+
     console.log(comment);
   };
 

--- a/src/common/components/templates/boardDetail/BoardDetailStyles.tsx
+++ b/src/common/components/templates/boardDetail/BoardDetailStyles.tsx
@@ -133,8 +133,25 @@ export const CommentInformationBox = styled.div`
   ${tw`
     flex
     flex-col
+    w-full
     pr-5
   `}
+`;
+
+export const CommentTextArea = styled.textarea`
+  ${tw`
+    pt-1
+    text-4.5
+    outline-none
+    resize-none
+  `}
+
+  &::placeholder {
+    ${tw`
+      text-4.5
+      text-gray-500
+    `}
+  }
 `;
 
 export const CommentSubmitButtonBox = styled.div`

--- a/src/hooks/login/mutate/usePostLogin.ts
+++ b/src/hooks/login/mutate/usePostLogin.ts
@@ -15,9 +15,7 @@ const usePostLogin = () => {
         password,
       }),
     onSuccess: (loginResponse: AxiosResponse) => {
-      console.log(
-        `로그인 성공, data: ${loginResponse}, token: ${loginResponse.data.token}, user: ${loginResponse.data.user.userId}`,
-      );
+      console.log(`로그인 성공`);
       localStorage.setItem("token", loginResponse.data.token);
       localStorage.setItem("owner", loginResponse.data.user.name);
       localStorage.setItem("userType", loginResponse.data.user.userType);


### PR DESCRIPTION
<!--
- PR 제목은 다음과 같이 작성해주세요!
- [#이슈번호] commit type: PR 제목
> ex) [#25] feat: HomePage 컴포넌트 구현 -->

## 📌 이슈 번호

- close #58 

## ✅ 작업 내용

- 댓글 작성 기능 구현
  - 댓글 작성 후, 등록 버튼 클릭 시 콘솔에 댓글 text 출력
- textarea로 댓글 작성 영역 style 설정
- 빈 글을 댓글로 등록할 경우, alert 창 출력

## 📷 스크린샷 (선택)

## 🔍 참고 자료 (선택)

<!-- 작업한 내용에 대한 부연 설명 -->
- 댓글 작성 기능
  - textarea에 onChange 이용
  - useState로 선언한 comment 상태값 이용

- textarea style 설정
  - 여러줄을 작성하고, 자동 줄바꿈이 가능하도록 input 보다 textarea를 사용하는 것이 적합하다고 판단
  - outline-none : textarea 클릭 시, 자동 생성 outline 제거
  - resize-none : 자동 생성 textarea 크기 조절 제거

- 참고 : useState 변수 선언과 isLoading 의 코드 순서에 유의해야합니다. (rendering 관련)
  - useGetSingleBoard 으로 요청 data가 들어오기 전에 렌더링이 되면, 참고하는 data 값이 없어 오류를 발생시킵니다.
  - isLoading을 참고하는 data 변수 코드 위에 위치시켜, 오류가 발생하지 않도록 합니다.

## 💭 기타 (선택)

<!--
- 추가로 필요한 작업 내용
- 리뷰 요구사항
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- API 연결 작업은 브랜치를 새로 생성하여 작업할 예정입니다 :)